### PR TITLE
Fix incorrect AlphaIdentifier decoding

### DIFF
--- a/pytoshop/image_resources.py
+++ b/pytoshop/image_resources.py
@@ -1023,8 +1023,7 @@ class AlphaIdentifiers(ImageResourceBlock):
                   length,       # type: int
                   header        # type: core.Header
                   ):            # type: (...) -> ImageResourceBlock
-        length = util.read_value(fd, 'I')
-        buf = fd.read(4 * length)
+        buf = fd.read(length)
         identifiers = list(np.frombuffer(buf, np.uint32))
         return cls(
             name=name, identifiers=identifiers


### PR DESCRIPTION
I found that AlphaIdentifier is incorrectly handled.
The data length is already specified by `length`, so there is no need to read a new length.
